### PR TITLE
Set node labels on kube-worker role in v1.19.7

### DIFF
--- a/roles/kube-worker/templates/kubeadm.yml.j2
+++ b/roles/kube-worker/templates/kubeadm.yml.j2
@@ -10,7 +10,7 @@ nodeRegistration:
   name: {{ kubernetes_hostname }}
   kubeletExtraArgs:
     cloud-provider: {{ kubernetes_cloud_provider }}
-    node-labels: "node.kubernetes.io/role={{ kubernetes_role}}"
+    node-labels: "node-role.kubernetes.io/{{ kubernetes_role}}="
 {% if kubernetes_taints | length > 0 %}
   taints:
 {{ kubernetes_taints | to_nice_yaml | indent(4, true) }}


### PR DESCRIPTION
Set correct node-label on Kubernetes worker nodes provisioned with kube-worker role.