### PR TITLE
Change apiVersion for storage CSIDriver

### DIFF
--- a/katalog/vsphere-csi/vsphere-csi-controller-deployment.yaml
+++ b/katalog/vsphere-csi/vsphere-csi-controller-deployment.yaml
@@ -140,7 +140,7 @@ metadata:
   name: internal-feature-states.csi.vsphere.vmware.com
   namespace: kube-system
 ---
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: csi.vsphere.vmware.com


### PR DESCRIPTION
storage.k8s.io/v1beta1 CSIDriver is deprecated in v1.19+, unavailable in v1.22+; use storage.k8s.io/v1 CSIDriver